### PR TITLE
Fix: showMonthDropdown does not list months in hijri

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -347,12 +347,20 @@ export function getWeekdayShortInLocale(locale, date) {
 }
 
 // TODO what is this format exactly?
-export function getMonthInLocale(locale, date, format) {
-  return locale.months(date, format);
+export function getMonthInLocale(locale, date, format, calendar = null) {
+  if (calendar == "hijri") {
+    return locale.iMonths(date, format);
+  } else {
+    return locale.months(date, format);
+  }
 }
 
-export function getMonthShortInLocale(locale, date) {
-  return locale.monthsShort(date);
+export function getMonthShortInLocale(locale, date, calendar = null) {
+  if (calendar == "hijri") {
+    return locale.iMonthsShort(date);
+  } else {
+    return locale.monthsShort(date);
+  }
 }
 
 // ** Utils for some components **

--- a/src/month_dropdown.jsx
+++ b/src/month_dropdown.jsx
@@ -13,7 +13,8 @@ export default class MonthDropdown extends React.Component {
     dateFormat: PropTypes.string.isRequired,
     month: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    useShortMonthInDropdown: PropTypes.bool
+    useShortMonthInDropdown: PropTypes.bool,
+    calendar: PropTypes.string
   };
 
   state = {
@@ -87,12 +88,18 @@ export default class MonthDropdown extends React.Component {
     const localeData = utils.getLocaleDataForLocale(this.props.locale);
     const monthNames = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(
       this.props.useShortMonthInDropdown
-        ? M => utils.getMonthShortInLocale(localeData, utils.newDate({ M }))
+        ? M =>
+            utils.getMonthShortInLocale(
+              localeData,
+              utils.newDate({ M }),
+              this.props.calendar
+            )
         : M =>
             utils.getMonthInLocale(
               localeData,
               utils.newDate({ M }),
-              this.props.dateFormat
+              this.props.dateFormat,
+              this.props.calendar
             )
     );
 


### PR DESCRIPTION
There is an option to showMonthDropdown in the react Datepicker.
If we use it here (in Hijri calendar) the dropdown items will list as Georgian even you set the calendar to "hijri"

I fixed it by adding calendar type check on monthDropdown class.
